### PR TITLE
possibility to publish the pose wrt another frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,24 @@ Software package and ROS wrappers of the [Aruco][1] Augmented Reality marker det
     ```
     ROS_NAMESPACE=/stereo/right rosrun image_proc image_proc image_raw:=image
     ```
- * Start the `single` node which will start tracking the specified marker.
+ * Start the `single` node which will start tracking the specified marker and will publish its pose in the camera frame
  
     ```
-    roslaunch aruco_ros single.launch markerId:=26 markerSize:=0.08 eye:="right" side:="r"
+    roslaunch aruco_ros single.launch markerId:=26 markerSize:=0.08 eye:="right"
     ```
+
+    the frame in which the pose is refered to can be chosen with the 'ref_frame' argument. The next example forces the marker pose to
+    be published with respect to the robot base_link frame:
+
+    ```
+    roslaunch aruco_ros single.launch markerId:=26 markerSize:=0.08 eye:="right" ref_frame:=/base_link
+    ```
+    
  * Visualize the result
  
     ```    
-    roslaunch reem_gazebo reem_gazebo.launch world:=floating_marker
+    rosrun image_view image_view image:=/aruco_single/result
     ```
-
 
 <img align="right" src="https://raw.github.com/pal-robotics/aruco_ros/master/etc/reem_gazebo_floating_marker.png"/>
 

--- a/launch/single.launch
+++ b/launch/single.launch
@@ -1,19 +1,21 @@
 <launch>
 
-    <arg name="markerId"     default="582"/>
-    <arg name="markerSize"   default="0.034"/>    <!-- in m -->
-    <arg name="eye"          default="left"/>
-    <arg name="marker_frame" default="aruco_marker_frame"/>
+    <arg name="markerId"        default="582"/>
+    <arg name="markerSize"      default="0.034"/>    <!-- in m -->
+    <arg name="eye"             default="left"/>
+    <arg name="marker_frame"    default="aruco_marker_frame"/>
+    <arg name="ref_frame"       default=""/>  <!-- leave empty and the pose will be published wrt param parent_name -->
 
 
     <node pkg="aruco_ros" type="single" name="aruco_single">
         <remap from="/camera_info" to="/stereo/$(arg eye)/camera_info" />
         <remap from="/image" to="/stereo/$(arg eye)/image_rect_color" />
         <param name="image_is_rectified" value="True"/>
-        <param name="marker_size" value="$(arg markerSize)"/>
-        <param name="marker_id"   value="$(arg markerId)"/>
-        <param name="parent_name" value="stereo_gazebo_$(arg eye)_camera_optical_frame"/>
-        <param name="child_name"  value="$(arg marker_frame)" />
+        <param name="marker_size"        value="$(arg markerSize)"/>
+        <param name="marker_id"          value="$(arg markerId)"/>
+        <param name="reference_frame"    value="$(arg ref_frame)"/>   <!-- frame in which the marker pose will be refered -->
+        <param name="camera_frame"       value="stereo_gazebo_$(arg eye)_camera_optical_frame"/>
+        <param name="marker_frame"       value="$(arg marker_frame)" />
     </node>
 
 </launch>


### PR DESCRIPTION
the aruco_single node now includes a transform_listener so that the marker pose wrt the camera frame can be expressed to any frame in the tf. The reference frame can be chosen with an optional argument in single.launch.

Fixed documentation in README.md and explain how to change the reference frame from command line.
