### PR TITLE
Add an install() rule for headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,3 +58,8 @@ add_executable(double src/simple_double.cpp
 add_dependencies(double ${PROJECT_NAME}_gencfg)
 target_link_libraries(double aruco ${catkin_LIBRARIES})
 
+
+install(DIRECTORY include/
+   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+   FILES_MATCHING PATTERN "*.h"
+)


### PR DESCRIPTION
This is needed by our build scripts.
