### PR TITLE
aruco_ros: Fixing superfluous (and broken) linker arg to -laruco

### DIFF
--- a/aruco_ros/CMakeLists.txt
+++ b/aruco_ros/CMakeLists.txt
@@ -31,12 +31,12 @@ include_directories(
 add_executable(single src/simple_single.cpp
                       src/aruco_ros_utils.cpp)
 add_dependencies(single ${PROJECT_NAME}_gencfg)
-target_link_libraries(single aruco ${catkin_LIBRARIES})
+target_link_libraries(single ${catkin_LIBRARIES})
 
 add_executable(double src/simple_double.cpp
                       src/aruco_ros_utils.cpp)
 add_dependencies(double ${PROJECT_NAME}_gencfg)
-target_link_libraries(double aruco ${catkin_LIBRARIES})
+target_link_libraries(double ${catkin_LIBRARIES})
 
 #############
 ## Install ##


### PR DESCRIPTION
Exposed when using `catkin build` or `catkin_make_isolated` but unlikely to cause problems when building with `catkin_make`. This bug prevents `aruco_ros` from being built with the stricter tools.
