### PR TITLE
More accurate ROS timestamps (callback triggering time)

### DIFF
--- a/aruco_ros/src/marker_publish.cpp
+++ b/aruco_ros/src/marker_publish.cpp
@@ -149,6 +149,7 @@ public:
     static tf::TransformBroadcaster br;
     if(cam_info_received_)
     {
+      ros::Time curr_stamp(ros::Time::now());
       cv_bridge::CvImagePtr cv_ptr;
       try
       {
@@ -163,7 +164,6 @@ public:
         mDetector_.detect(inImage_, markers_, camParam_, marker_size_, false);
         marker_msg_->markers.resize(markers_.size());
 
-        ros::Time curr_stamp(ros::Time::now());
         marker_msg_->header.stamp = curr_stamp;
         marker_msg_->header.seq++;
 

--- a/aruco_ros/src/simple_double.cpp
+++ b/aruco_ros/src/simple_double.cpp
@@ -81,6 +81,7 @@ void image_callback(const sensor_msgs::ImageConstPtr& msg)
   static tf::TransformBroadcaster br;
   if(cam_info_received)
   {
+    ros::Time curr_stamp(ros::Time::now());
     cv_bridge::CvImagePtr cv_ptr;
     try
     {
@@ -105,7 +106,7 @@ void image_callback(const sensor_msgs::ImageConstPtr& msg)
         if ( markers[i].id == marker_id1 )
         {
           tf::Transform transform = aruco_ros::arucoMarker2Tf(markers[i]);
-          br.sendTransform(tf::StampedTransform(transform, ros::Time::now(),
+          br.sendTransform(tf::StampedTransform(transform, curr_stamp,
                                                 parent_name, child_name1));
           geometry_msgs::Pose poseMsg;
           tf::poseTFToMsg(transform, poseMsg);
@@ -114,7 +115,7 @@ void image_callback(const sensor_msgs::ImageConstPtr& msg)
         else if ( markers[i].id == marker_id2 )
         {
           tf::Transform transform = aruco_ros::arucoMarker2Tf(markers[i]);
-          br.sendTransform(tf::StampedTransform(transform, ros::Time::now(),
+          br.sendTransform(tf::StampedTransform(transform, curr_stamp,
                                                 parent_name, child_name2));
           geometry_msgs::Pose poseMsg;
           tf::poseTFToMsg(transform, poseMsg);
@@ -193,7 +194,7 @@ void image_callback(const sensor_msgs::ImageConstPtr& msg)
       {
         //show input with augmented information
         cv_bridge::CvImage out_msg;
-        out_msg.header.stamp = ros::Time::now();
+        out_msg.header.stamp = curr_stamp;
         out_msg.encoding = sensor_msgs::image_encodings::RGB8;
         out_msg.image = inImage;
         image_pub.publish(out_msg.toImageMsg());
@@ -203,7 +204,7 @@ void image_callback(const sensor_msgs::ImageConstPtr& msg)
       {
         //show also the internal image resulting from the threshold operation
         cv_bridge::CvImage debug_msg;
-        debug_msg.header.stamp = ros::Time::now();
+        debug_msg.header.stamp = curr_stamp;
         debug_msg.encoding = sensor_msgs::image_encodings::MONO8;
         debug_msg.image = mDetector.getThresholdedImage();
         debug_pub.publish(debug_msg.toImageMsg());

--- a/aruco_ros/src/simple_single.cpp
+++ b/aruco_ros/src/simple_single.cpp
@@ -151,6 +151,7 @@ public:
     static tf::TransformBroadcaster br;
     if(cam_info_received)
     {
+      ros::Time curr_stamp(ros::Time::now());
       cv_bridge::CvImagePtr cv_ptr;
       try
       {
@@ -183,13 +184,13 @@ public:
               * static_cast<tf::Transform>(rightToLeft) 
               * transform;
 
-            tf::StampedTransform stampedTransform(transform, ros::Time::now(),
+            tf::StampedTransform stampedTransform(transform, curr_stamp,
                                                   reference_frame, marker_frame);
             br.sendTransform(stampedTransform);
             geometry_msgs::PoseStamped poseMsg;
             tf::poseTFToMsg(transform, poseMsg.pose);
             poseMsg.header.frame_id = reference_frame;
-            poseMsg.header.stamp = ros::Time::now();
+            poseMsg.header.stamp = curr_stamp;
             pose_pub.publish(poseMsg);
 
             geometry_msgs::TransformStamped transformMsg;
@@ -218,7 +219,7 @@ public:
         {
           //show input with augmented information
           cv_bridge::CvImage out_msg;
-          out_msg.header.stamp = ros::Time::now();
+          out_msg.header.stamp = curr_stamp;
           out_msg.encoding = sensor_msgs::image_encodings::RGB8;
           out_msg.image = inImage;
           image_pub.publish(out_msg.toImageMsg());
@@ -228,7 +229,7 @@ public:
         {
           //show also the internal image resulting from the threshold operation
           cv_bridge::CvImage debug_msg;
-          debug_msg.header.stamp = ros::Time::now();
+          debug_msg.header.stamp = curr_stamp;
           debug_msg.encoding = sensor_msgs::image_encodings::MONO8;
           debug_msg.image = mDetector.getThresholdedImage();
           debug_pub.publish(debug_msg.toImageMsg());


### PR DESCRIPTION
This commit ensures that:
- all published msgs in a callback have the same timestamp
- the time is as close as possible to the frame grabbing time (as fast as the marker detection may be, the delay might affect TF interpolation in an unacceptable way for applications like visual servoing)