### PR TITLE
Fix compilation error in Ubuntu 16.04

### DIFF
--- a/aruco/src/aruco/aruco_selectoptimalmarkers.cpp
+++ b/aruco/src/aruco/aruco_selectoptimalmarkers.cpp
@@ -35,6 +35,7 @@ or implied, of Rafael Muñoz Salinas.
 #include <opencv2/highgui/highgui.hpp>
 #include <aruco/aruco.h>
 #include <iostream>
+#include <limits>
 #include <aruco/arucofidmarkers.h>
 using namespace cv;
 using namespace std;


### PR DESCRIPTION
With this change, `aruco_ros` compiles properly in Ubuntu 16.04, ROS kinetic.