### PR TITLE
Change default threshold to match defaults of aruco marker detector

### DIFF
--- a/aruco_ros/cfg/ArucoThreshold.cfg
+++ b/aruco_ros/cfg/ArucoThreshold.cfg
@@ -5,8 +5,8 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("param1", int_t, 0, "blockSize parameter of cv::adaptiveThreshold", 4, 1, 15)
-gen.add("param2", int_t, 0, "C parameter of cv::adaptiveThreshold", 8, 1, 15)
+gen.add("param1", int_t, 0, "blockSize parameter of cv::adaptiveThreshold", 7, 1, 15)
+gen.add("param2", int_t, 0, "C parameter of cv::adaptiveThreshold", 7, 1, 15)
 gen.add("normalizeImage", bool_t, 0, "normalizeImage", True)
 gen.add("dctComponentsToRemove", int_t, 0, "DCT components to remove", 2, 1, 4)
 gen.add("degree", int_t, 0, "Degree to rotate", 0, 0, 360)


### PR DESCRIPTION
Changed default threshold parameters to match aruco's markerdetector defaults.

This is motivated by https://github.com/pal-robotics/aruco_ros/pull/31 because the behaviour will change, it will go from using 7 and 7, to 4 and 8 set by the dynamic reconfigure.

And also a few experiments here:
Debugging with the current parameters (4,8):

![aruco_4_8](https://user-images.githubusercontent.com/3469405/28370753-599d694a-6c9b-11e7-854b-dc2976e009d5.png)

Debugging with marker detector default parameters (7,7) proposed by this MR:
![aruco_7_7](https://user-images.githubusercontent.com/3469405/28370754-599f9e72-6c9b-11e7-8cf3-224960b2ebe8.png)
