### PR TITLE
Fixed OpenCV Calib3D link error on ROS Kinetic

### DIFF
--- a/aruco_ros/CMakeLists.txt
+++ b/aruco_ros/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(aruco_ros)
 
+find_package(OpenCV REQUIRED)
+
 find_package(catkin REQUIRED COMPONENTS
   cv_bridge
   dynamic_reconfigure
@@ -26,22 +28,23 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
 )
 
 add_executable(single src/simple_single.cpp
                       src/aruco_ros_utils.cpp)
 add_dependencies(single ${PROJECT_NAME}_gencfg)
-target_link_libraries(single ${catkin_LIBRARIES})
+target_link_libraries(single ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 add_executable(double src/simple_double.cpp
                       src/aruco_ros_utils.cpp)
 add_dependencies(double ${PROJECT_NAME}_gencfg)
-target_link_libraries(double ${catkin_LIBRARIES})
+target_link_libraries(double ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 add_executable(marker_publisher src/marker_publish.cpp
                                 src/aruco_ros_utils.cpp)
 add_dependencies(marker_publisher ${PROJECT_NAME}_gencfg)
-target_link_libraries(marker_publisher ${catkin_LIBRARIES})
+target_link_libraries(marker_publisher ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 #############
 ## Install ##


### PR DESCRIPTION
Fix for issue #40: Build fail when using catkin build instead of catkin_make