### PR TITLE
Adding explicit build order

### DIFF
--- a/aruco_ros/CMakeLists.txt
+++ b/aruco_ros/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(double ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 add_executable(marker_publisher src/marker_publish.cpp
                                 src/aruco_ros_utils.cpp)
-add_dependencies(marker_publisher ${PROJECT_NAME}_gencfg aruco_msgs_generate_messages_cpp)
+add_dependencies(marker_publisher ${PROJECT_NAME}_gencfg ${catkin_EXPORTED_TARGETS})
 target_link_libraries(marker_publisher ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 #############

--- a/aruco_ros/CMakeLists.txt
+++ b/aruco_ros/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(double ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 add_executable(marker_publisher src/marker_publish.cpp
                                 src/aruco_ros_utils.cpp)
-add_dependencies(marker_publisher ${PROJECT_NAME}_gencfg)
+add_dependencies(marker_publisher ${PROJECT_NAME}_gencfg aruco_msgs_generate_messages_cpp)
 target_link_libraries(marker_publisher ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 #############


### PR DESCRIPTION
After observing the following build error:

```
aruco_ros/aruco_ros/src/marker_publish.cpp:45:36: fatal error: aruco_msgs/MarkerArray.h: No such file or directory
compilation terminated.
```
I suspected the message header files generated from `aruco_msgs` were not ready in time to be referenced during compilation of `marker_publisher`. The one-line change in this PR explicitly tells catkin that these message header files must be generated before compiling `marker_publisher`, and solves this issue according to my testing.