### PR TITLE
Sets the 'useRectifiedImages' member from a parameter before it uses it

### DIFF
--- a/aruco_ros/src/marker_publish.cpp
+++ b/aruco_ros/src/marker_publish.cpp
@@ -90,11 +90,12 @@ public:
     if(useCamInfo_)
     {
       sensor_msgs::CameraInfoConstPtr msg = ros::topic::waitForMessage<sensor_msgs::CameraInfo>("/camera_info", nh_);//, 10.0);
-      camParam_ = aruco_ros::rosCameraInfo2ArucoCamParams(*msg, useRectifiedImages_);
+
       nh_.param<double>("marker_size", marker_size_, 0.05);
       nh_.param<bool>("image_is_rectified", useRectifiedImages_, true);
       nh_.param<std::string>("reference_frame", reference_frame_, "");
       nh_.param<std::string>("camera_frame", camera_frame_, "");
+      camParam_ = aruco_ros::rosCameraInfo2ArucoCamParams(*msg, useRectifiedImages_);
       ROS_ASSERT(not (camera_frame_.empty() and not reference_frame_.empty()));
       if(reference_frame_.empty())
         reference_frame_ = camera_frame_;


### PR DESCRIPTION
Minor change to prevent using a variable before it's used.