### PR TITLE
Add rotate_marker_axis parameter

### DIFF
--- a/aruco_ros/include/aruco_ros/aruco_ros_utils.h
+++ b/aruco_ros/include/aruco_ros/aruco_ros_utils.h
@@ -19,7 +19,7 @@ namespace aruco_ros
                                                        bool useRectifiedParameters);
 
   //FIXME: make parameter const as soon as the used function is also const
-  tf::Transform arucoMarker2Tf(const aruco::Marker& marker);
+  tf::Transform arucoMarker2Tf(const aruco::Marker& marker, bool rotate_marker_axis=true);
 
 }
 #endif // ARUCO_ROS_UTILS_H

--- a/aruco_ros/src/aruco_ros_utils.cpp
+++ b/aruco_ros/src/aruco_ros_utils.cpp
@@ -42,7 +42,7 @@ aruco::CameraParameters aruco_ros::rosCameraInfo2ArucoCamParams(const sensor_msg
     return aruco::CameraParameters(cameraMatrix, distorsionCoeff, size);
 }
 
-tf::Transform aruco_ros::arucoMarker2Tf(const aruco::Marker &marker)
+tf::Transform aruco_ros::arucoMarker2Tf(const aruco::Marker &marker, bool rotate_marker_axis)
 {
     cv::Mat rot(3, 3, CV_64FC1);
     cv::Mat Rvec64;
@@ -51,21 +51,24 @@ tf::Transform aruco_ros::arucoMarker2Tf(const aruco::Marker &marker)
     cv::Mat tran64;
     marker.Tvec.convertTo(tran64, CV_64FC1);
 
-    cv::Mat rotate_to_ros(3, 3, CV_64FC1);
-    // -1 0 0
-    // 0 0 1
-    // 0 1 0
-    rotate_to_ros.at<double>(0,0) = -1.0;
-    rotate_to_ros.at<double>(0,1) = 0.0;
-    rotate_to_ros.at<double>(0,2) = 0.0;
-    rotate_to_ros.at<double>(1,0) = 0.0;
-    rotate_to_ros.at<double>(1,1) = 0.0;
-    rotate_to_ros.at<double>(1,2) = 1.0;
-    rotate_to_ros.at<double>(2,0) = 0.0;
-    rotate_to_ros.at<double>(2,1) = 1.0;
-    rotate_to_ros.at<double>(2,2) = 0.0;
-    rot = rot*rotate_to_ros.t();
-
+    // Rotate axis direction as to fit ROS (?)
+    if (rotate_marker_axis)
+    {
+      cv::Mat rotate_to_ros(3, 3, CV_64FC1);
+      // -1 0 0
+      // 0 0 1
+      // 0 1 0
+      rotate_to_ros.at<double>(0,0) = -1.0;
+      rotate_to_ros.at<double>(0,1) = 0.0;
+      rotate_to_ros.at<double>(0,2) = 0.0;
+      rotate_to_ros.at<double>(1,0) = 0.0;
+      rotate_to_ros.at<double>(1,1) = 0.0;
+      rotate_to_ros.at<double>(1,2) = 1.0;
+      rotate_to_ros.at<double>(2,0) = 0.0;
+      rotate_to_ros.at<double>(2,1) = 1.0;
+      rotate_to_ros.at<double>(2,2) = 0.0;
+      rot = rot*rotate_to_ros.t();
+    }
     tf::Matrix3x3 tf_rot(rot.at<double>(0,0), rot.at<double>(0,1), rot.at<double>(0,2),
                          rot.at<double>(1,0), rot.at<double>(1,1), rot.at<double>(1,2),
                          rot.at<double>(2,0), rot.at<double>(2,1), rot.at<double>(2,2));

--- a/aruco_ros/src/marker_publish.cpp
+++ b/aruco_ros/src/marker_publish.cpp
@@ -60,6 +60,7 @@ private:
   std::string camera_frame_;
   std::string reference_frame_;
   double marker_size_;
+  bool rotate_marker_axis_;
 
   // ROS pub-sub
   ros::NodeHandle nh_;
@@ -95,6 +96,7 @@ public:
       nh_.param<bool>("image_is_rectified", useRectifiedImages_, true);
       nh_.param<std::string>("reference_frame", reference_frame_, "");
       nh_.param<std::string>("camera_frame", camera_frame_, "");
+      nh_.param<bool>("rotate_marker_axis", rotate_marker_axis_, true);
       ROS_ASSERT(not (camera_frame_.empty() and not reference_frame_.empty()));
       if(reference_frame_.empty())
         reference_frame_ = camera_frame_;
@@ -205,7 +207,7 @@ public:
             for(size_t i=0; i<markers_.size(); ++i)
             {
               aruco_msgs::Marker & marker_i = marker_msg_->markers.at(i);
-              tf::Transform transform = aruco_ros::arucoMarker2Tf(markers_[i]);
+              tf::Transform transform = aruco_ros::arucoMarker2Tf(markers_[i], rotate_marker_axis_);
               transform = static_cast<tf::Transform>(cameraToReference) * transform;
               tf::poseTFToMsg(transform, marker_i.pose.pose);
               marker_i.header.frame_id = reference_frame_;

--- a/aruco_ros/src/simple_single.cpp
+++ b/aruco_ros/src/simple_single.cpp
@@ -74,6 +74,7 @@ private:
 
   double marker_size;
   int marker_id;
+  bool rotate_marker_axis_;
 
   ros::NodeHandle nh;
   image_transport::ImageTransport it;
@@ -131,6 +132,7 @@ public:
     nh.param<std::string>("camera_frame", camera_frame, "");
     nh.param<std::string>("marker_frame", marker_frame, "");
     nh.param<bool>("image_is_rectified", useRectifiedImages, true);
+    nh.param<bool>("rotate_marker_axis", rotate_marker_axis_, true);
 
     ROS_ASSERT(camera_frame != "" && marker_frame != "");
 
@@ -215,7 +217,7 @@ public:
           // only publishing the selected marker
           if(markers[i].id == marker_id)
           {
-            tf::Transform transform = aruco_ros::arucoMarker2Tf(markers[i]);
+            tf::Transform transform = aruco_ros::arucoMarker2Tf(markers[i], rotate_marker_axis_);
             tf::StampedTransform cameraToReference;
             cameraToReference.setIdentity();
 


### PR DESCRIPTION
This add a boolean parameter named `rotate_marker_axis` for #51 .
Default is true and it does not effect current behavior. When it is set false, the unnecessary rotation is skipped and the orientation of tf should be identical to the marker detection results. 