### PR TITLE
Remove deprecated corner_refinement parameter from lanuch file.

### DIFF
--- a/aruco_ros/launch/single.launch
+++ b/aruco_ros/launch/single.launch
@@ -5,7 +5,6 @@
     <arg name="eye"             default="left"/>
     <arg name="marker_frame"    default="aruco_marker_frame"/>
     <arg name="ref_frame"       default=""/>  <!-- leave empty and the pose will be published wrt param parent_name -->
-    <arg name="corner_refinement" default="LINES" /> <!-- NONE, HARRIS, LINES, SUBPIX -->
 
 
     <node pkg="aruco_ros" type="single" name="aruco_single">
@@ -17,7 +16,6 @@
         <param name="reference_frame"    value="$(arg ref_frame)"/>   <!-- frame in which the marker pose will be refered -->
         <param name="camera_frame"       value="stereo_gazebo_$(arg eye)_camera_optical_frame"/>
         <param name="marker_frame"       value="$(arg marker_frame)" />
-        <param name="corner_refinement"  value="$(arg corner_refinement)" />
     </node>
 
 </launch>


### PR DESCRIPTION
The parameter has been removed in ArUco 3.0.0., and simple_single.cpp
shows warning for it.