### PR TITLE
fix(cmake): Broken export of header files an library targets.

### DIFF
--- a/aruco_ros/CMakeLists.txt
+++ b/aruco_ros/CMakeLists.txt
@@ -1,14 +1,12 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10.2)
 project(aruco_ros)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 20)
 endif()
-set(CMAKE_CXX_STANDARD 11) # C++11...
-set(CMAKE_CXX_STANDARD_REQUIRED ON) #...is required...
-set(CMAKE_CXX_EXTENSIONS ON) #...with compiler extensions like gnu++11
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS
+# Public dependencies.
+set(dependencies
     OpenCV
     cv_bridge
     geometry_msgs
@@ -23,98 +21,112 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
     sensor_msgs
     visualization_msgs
 )
+
 find_package(ament_cmake REQUIRED)
-foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
-  find_package(${Dependency} REQUIRED)
+foreach(DEP ${dependencies})
+  find_package(${DEP} REQUIRED)
 endforeach()
 
-#generate_dynamic_reconfigure_options(
-#  cfg/ArucoThreshold.cfg
-#)
-
-add_library(aruco_ros_utils SHARED src/aruco_ros_utils.cpp)
-target_include_directories(aruco_ros_utils
-  PUBLIC
-  include)
-
-target_include_directories(aruco_ros_utils
-  SYSTEM PUBLIC
-  ${OpenCV_INCLUDE_DIRS}
+# Build library.
+add_library(${PROJECT_NAME}_utils SHARED
+  src/aruco_ros_utils.cpp
 )
-ament_target_dependencies(aruco_ros_utils ${THIS_PACKAGE_INCLUDE_DEPENDS})
-target_link_libraries(aruco_ros_utils ${OpenCV_LIBRARIES})
+target_include_directories(${PROJECT_NAME}_utils
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 
+target_link_libraries(${PROJECT_NAME}_utils PUBLIC
+  ${OpenCV_LIBRARIES}
+  tf2_geometry_msgs::tf2_geometry_msgs
+  cv_bridge::cv_bridge
+)
+
+target_include_directories(${PROJECT_NAME}_utils PUBLIC
+  ${OpenCV_INCLUDE_DIRS}
+  ${aruco_INCLUDE_DIRS}
+  ${sensor_msgs_INCLUDE_DIRS}
+  ${visualization_msgs_INCLUDE_DIRS}
+)
+
+# Build executables.
 add_executable(single src/simple_single.cpp
                       src/aruco_ros_utils.cpp)
+target_link_libraries(single
+  ${PROJECT_NAME}_utils  
 
-target_include_directories(single
-  PUBLIC
-  include)
+  ${aruco_LIBRARIES}
+  ${OpenCV_LIBRARIES}
+  ${visualization_msgs_TARGETS}
 
-target_include_directories(single
-  SYSTEM PUBLIC
+  image_transport::image_transport
+)
+target_include_directories(single PUBLIC
   ${OpenCV_INCLUDE_DIRS}
 )
-ament_target_dependencies(single ${THIS_PACKAGE_INCLUDE_DEPENDS})
-target_link_libraries(single ${OpenCV_LIBRARIES})
 
 add_executable(double src/simple_double.cpp
                       src/aruco_ros_utils.cpp)
-target_include_directories(double
-  PUBLIC
-  include)
+target_link_libraries(double
+  ${PROJECT_NAME}_utils
 
-target_include_directories(double
-  SYSTEM PUBLIC
+  ${aruco_LIBRARIES}
+  ${OpenCV_LIBRARIES}
+
+  image_transport::image_transport
+)
+target_include_directories(double PUBLIC
   ${OpenCV_INCLUDE_DIRS}
 )
-ament_target_dependencies(double ${THIS_PACKAGE_INCLUDE_DEPENDS})
-target_link_libraries(double ${OpenCV_LIBRARIES})
 
 add_executable(marker_publisher src/marker_publish.cpp
                                 src/aruco_ros_utils.cpp)
-target_include_directories(marker_publisher
-  PUBLIC
-  include)
-
-target_include_directories(marker_publisher
-  SYSTEM PUBLIC
-  ${OpenCV_INCLUDE_DIRS}
+target_link_libraries(marker_publisher
+  ${PROJECT_NAME}_utils
+  
+  ${aruco_LIBRARIES}
+  ${aruco_msgs_LIBRARIES}
+  ${OpenCV_LIBRARIES}
+  
+  image_transport::image_transport
 )
-ament_target_dependencies(marker_publisher ${THIS_PACKAGE_INCLUDE_DEPENDS})
-target_link_libraries(marker_publisher ${OpenCV_LIBRARIES})
+target_include_directories(marker_publisher PUBLIC
+  ${OpenCV_INCLUDE_DIRS}
+  ${aruco_msgs_INCLUDE_DIRS}
+)
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
+# Install library and resources.
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+  FILES_MATCHING PATTERN "*.hpp"
+)
 
-  list(APPEND AMENT_LINT_AUTO_EXCLUDE
-    ament_cmake_copyright
-  )
-  ament_lint_auto_find_test_dependencies()
-endif()
-
-#############
-## Install ##
-#############
-
-install(TARGETS aruco_ros_utils
+install(TARGETS ${PROJECT_NAME}_utils
+  EXPORT export_${PROJECT_NAME}_utils
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-
-install(TARGETS marker_publisher single double
-  DESTINATION lib/${PROJECT_NAME})
-
-install(DIRECTORY include/
-        DESTINATION include
-        FILES_MATCHING PATTERN "*.h"
+  RUNTIME DESTINATION bin
 )
 
-foreach(dir etc launch)
-    install(DIRECTORY ${dir}/
-            DESTINATION share/${PROJECT_NAME}/${dir})
-endforeach()
+install(TARGETS single
+  DESTINATION lib/${PROJECT_NAME}
+)
 
+install(TARGETS double
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(TARGETS marker_publisher
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+# Exports.
+ament_export_include_directories(include)
+ament_export_targets(export_${PROJECT_NAME}_utils HAS_LIBRARY_TARGET)
+ament_export_dependencies(${dependencies})
 ament_package()
-
-


### PR DESCRIPTION
The aruco_ros package in its current state doesn't export its header files, since it searches for "*.h" files, but uses a "*.hpp" instead. Also, it seems not to export any of the usual variables pointing towards the library. I reimplemented the CMakeLists.txt of aruco_ros to fix the broken export of header files and library targets. It now can be included referencing "${aruco_ros_TARGETS}" and "${aruco_ros_INCLUDE_DIRS}".