### PR TITLE
Consistent naming for private variables of an class

### DIFF
--- a/aruco_ros/src/marker_publish.cpp
+++ b/aruco_ros/src/marker_publish.cpp
@@ -59,7 +59,7 @@ using namespace std::chrono_literals;
 class ArucoMarkerPublisher : public rclcpp::Node
 {
 private:
-  rclcpp::Node::SharedPtr subNode;
+  rclcpp::Node::SharedPtr subNode_;
   // ArUco stuff
   aruco::MarkerDetector mDetector_;
   aruco::CameraParameters camParam_;
@@ -96,7 +96,7 @@ public:
 
   bool setup()
   {
-    subNode = this->create_sub_node(this->get_name());
+    subNode_ = this->create_sub_node(this->get_name());
     // Declare node parameters
     this->declare_parameter<double>("marker_size", 0.05);
     this->declare_parameter<std::string>("reference_frame", "");
@@ -136,9 +136,9 @@ public:
 
     image_pub_ = it_->advertise(this->get_name() + std::string("/result"), 1);
     debug_pub_ = it_->advertise(this->get_name() + std::string("/debug"), 1);
-    marker_pub_ = subNode->create_publisher<aruco_msgs::msg::MarkerArray>("markers", 100);
+    marker_pub_ = subNode_->create_publisher<aruco_msgs::msg::MarkerArray>("markers", 100);
     marker_list_pub_ =
-      subNode->create_publisher<std_msgs::msg::UInt32MultiArray>("markers_list", 10);
+      subNode_->create_publisher<std_msgs::msg::UInt32MultiArray>("markers_list", 10);
 
     marker_msg_ = aruco_msgs::msg::MarkerArray::Ptr(new aruco_msgs::msg::MarkerArray());
     marker_msg_->header.frame_id = reference_frame_;

--- a/aruco_ros/src/simple_double.cpp
+++ b/aruco_ros/src/simple_double.cpp
@@ -58,113 +58,113 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 
-rclcpp::Node::SharedPtr node = nullptr;
-rclcpp::Node::SharedPtr subNode = nullptr;
-cv::Mat inImage;
-aruco::CameraParameters camParam;
-bool useRectifiedImages, normalizeImageIllumination;
-int dctComponentsToRemove;
-aruco::MarkerDetector mDetector;
-std::vector<aruco::Marker> markers;
-rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr cam_info_sub;
-bool cam_info_received;
-image_transport::Publisher image_pub;
-image_transport::Publisher debug_pub;
-rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr pose_pub1;
-rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr pose_pub2;
-std::string child_name1;  // NOLINT(runtime/string)
-std::string parent_name;  // NOLINT(runtime/string)
-std::string child_name2;  // NOLINT(runtime/string)
+rclcpp::Node::SharedPtr node_ = nullptr;
+rclcpp::Node::SharedPtr subNode_ = nullptr;
+cv::Mat inImage_;
+aruco::CameraParameters camParam_;
+bool useRectifiedImages_, normalizeImageIllumination_;
+int dctComponentsToRemove_;
+aruco::MarkerDetector mDetector_;
+std::vector<aruco::Marker> markers_;
+rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr cam_info_sub_;
+bool cam_info_received_;
+image_transport::Publisher image_pub_;
+image_transport::Publisher debug_pub_;
+rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr pose_pub1_;
+rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr pose_pub2_;
+std::string child_name1_;  // NOLINT(runtime/string)
+std::string parent_name_;  // NOLINT(runtime/string)
+std::string child_name2_;  // NOLINT(runtime/string)
 
-double marker_size;
-int marker_id1;
-int marker_id2;
+double marker_size_;
+int marker_id1_;
+int marker_id2_;
 std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
 void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
 {
   double ticksBefore = cv::getTickCount();
-  if (cam_info_received) {
+  if (cam_info_received_) {
     builtin_interfaces::msg::Time curr_stamp = msg->header.stamp;
     cv_bridge::CvImagePtr cv_ptr;
     try {
       cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::RGB8);
-      inImage = cv_ptr->image;
+      inImage_ = cv_ptr->image;
 
-      if (normalizeImageIllumination) {
-        RCLCPP_WARN(node->get_logger(), "normalizeImageIllumination is unimplemented!");
+      if (normalizeImageIllumination_) {
+        RCLCPP_WARN(node_->get_logger(), "normalizeImageIllumination is unimplemented!");
 //        cv::Mat inImageNorm;
-//        pal_vision_util::dctNormalization(inImage, inImageNorm, dctComponentsToRemove);
-//        inImage = inImageNorm;
+//        pal_vision_util::dctNormalization(inImage_, inImageNorm, dctComponentsToRemove_);
+//        inImage_ = inImageNorm;
       }
 
-      // detection results will go into "markers"
-      markers.clear();
+      // detection results will go into "markers_"
+      markers_.clear();
       // ok, let's detect
-      mDetector.detect(inImage, markers, camParam, marker_size, false);
+      mDetector_.detect(inImage_, markers_, camParam_, marker_size_, false);
       // for each marker, draw info and its boundaries in the image
-      for (unsigned int i = 0; i < markers.size(); ++i) {
+      for (unsigned int i = 0; i < markers_.size(); ++i) {
         // only publishing the selected marker
-        if (markers[i].id == marker_id1) {
-          tf2::Transform transform = aruco_ros::arucoMarker2Tf2(markers[i]);
+        if (markers_[i].id == marker_id1_) {
+          tf2::Transform transform = aruco_ros::arucoMarker2Tf2(markers_[i]);
           geometry_msgs::msg::TransformStamped m1_transform;
-          m1_transform.header.frame_id = parent_name;
+          m1_transform.header.frame_id = parent_name_;
           m1_transform.header.stamp = curr_stamp;
-          m1_transform.child_frame_id = child_name1;
+          m1_transform.child_frame_id = child_name1_;
           tf2::toMsg(transform, m1_transform.transform);
           tf_broadcaster_->sendTransform(m1_transform);
           geometry_msgs::msg::Pose poseMsg;
           tf2::toMsg(transform, poseMsg);
-          pose_pub1->publish(poseMsg);
-        } else if (markers[i].id == marker_id2) {
-          tf2::Transform transform = aruco_ros::arucoMarker2Tf2(markers[i]);
+          pose_pub1_->publish(poseMsg);
+        } else if (markers_[i].id == marker_id2_) {
+          tf2::Transform transform = aruco_ros::arucoMarker2Tf2(markers_[i]);
           geometry_msgs::msg::TransformStamped m2_transform;
-          m2_transform.header.frame_id = parent_name;
+          m2_transform.header.frame_id = parent_name_;
           m2_transform.header.stamp = curr_stamp;
-          m2_transform.child_frame_id = child_name2;
+          m2_transform.child_frame_id = child_name2_;
           tf2::toMsg(transform, m2_transform.transform);
           tf_broadcaster_->sendTransform(m2_transform);
           geometry_msgs::msg::Pose poseMsg;
           tf2::toMsg(transform, poseMsg);
-          pose_pub2->publish(poseMsg);
+          pose_pub2_->publish(poseMsg);
         }
 
-        // but drawing all the detected markers
-        markers[i].draw(inImage, cv::Scalar(0, 0, 255), 2);
+        // but drawing all the detected markers_
+        markers_[i].draw(inImage_, cv::Scalar(0, 0, 255), 2);
       }
 
       // paint a circle in the center of the image
       cv::circle(
-        inImage, cv::Point(inImage.cols / 2, inImage.rows / 2), 4, cv::Scalar(0, 255, 0),
+        inImage_, cv::Point(inImage_.cols / 2, inImage_.rows / 2), 4, cv::Scalar(0, 255, 0),
         1);
 
-      if (markers.size() == 2) {
+      if (markers_.size() == 2) {
         float x[2], y[2], u[2], v[2];
         for (unsigned int i = 0; i < 2; ++i) {
           RCLCPP_DEBUG_STREAM(
-            node->get_logger(),
-            "Marker(" << i << ") at camera coordinates = (" << markers[i].Tvec.at<float>(
+            node_->get_logger(),
+            "Marker(" << i << ") at camera coordinates = (" << markers_[i].Tvec.at<float>(
               0,
               0) << ", " <<
-              markers[i].Tvec.at<float>(1, 0) << ", " << markers[i].Tvec.at<float>(2, 0));
+              markers_[i].Tvec.at<float>(1, 0) << ", " << markers_[i].Tvec.at<float>(2, 0));
           // normalized coordinates of the marker
-          x[i] = markers[i].Tvec.at<float>(0, 0) / markers[i].Tvec.at<float>(2, 0);
-          y[i] = markers[i].Tvec.at<float>(1, 0) / markers[i].Tvec.at<float>(2, 0);
+          x[i] = markers_[i].Tvec.at<float>(0, 0) / markers_[i].Tvec.at<float>(2, 0);
+          y[i] = markers_[i].Tvec.at<float>(1, 0) / markers_[i].Tvec.at<float>(2, 0);
           // undistorted pixel
           u[i] = x[i] *
-            camParam.CameraMatrix.at<float>(0, 0) + camParam.CameraMatrix.at<float>(0, 2);
+            camParam_.CameraMatrix.at<float>(0, 0) + camParam_.CameraMatrix.at<float>(0, 2);
           v[i] = y[i] *
-            camParam.CameraMatrix.at<float>(1, 1) + camParam.CameraMatrix.at<float>(1, 2);
+            camParam_.CameraMatrix.at<float>(1, 1) + camParam_.CameraMatrix.at<float>(1, 2);
         }
 
         RCLCPP_DEBUG_STREAM(
-          node->get_logger(),
+          node_->get_logger(),
           "Mid point between the two markers in the image = (" << (x[0] + x[1]) / 2 << ", " <<
             (y[0] + y[1]) / 2 << ")");
 
-//        // paint a circle in the mid point of the normalized coordinates of both markers
+//        // paint a circle in the mid point of the normalized coordinates of both markers_
 //        cv::circle(
-//          inImage, cv::Point((u[0] + u[1]) / 2, (v[0] + v[1]) / 2), 3, cv::Scalar(
+//          inImage_, cv::Point((u[0] + u[1]) / 2, (v[0] + v[1]) / 2), 3, cv::Scalar(
 //            0, 0,
 //            255),
 //          cv::FILLED);
@@ -172,56 +172,56 @@ void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
         // compute the midpoint in 3D:
         float midPoint3D[3];  // 3D point
         for (unsigned int i = 0; i < 3; ++i) {
-          midPoint3D[i] = (markers[0].Tvec.at<float>(i, 0) + markers[1].Tvec.at<float>(i, 0)) / 2;
+          midPoint3D[i] = (markers_[0].Tvec.at<float>(i, 0) + markers_[1].Tvec.at<float>(i, 0)) / 2;
         }
         // now project the 3D mid point to normalized coordinates
         float midPointNormalized[2];
         midPointNormalized[0] = midPoint3D[0] / midPoint3D[2];  // x
         midPointNormalized[1] = midPoint3D[1] / midPoint3D[2];  // y
         u[0] = midPointNormalized[0] *
-          camParam.CameraMatrix.at<float>(0, 0) + camParam.CameraMatrix.at<float>(0, 2);
+          camParam_.CameraMatrix.at<float>(0, 0) + camParam_.CameraMatrix.at<float>(0, 2);
         v[0] = midPointNormalized[1] *
-          camParam.CameraMatrix.at<float>(1, 1) + camParam.CameraMatrix.at<float>(1, 2);
+          camParam_.CameraMatrix.at<float>(1, 1) + camParam_.CameraMatrix.at<float>(1, 2);
 
         RCLCPP_DEBUG_STREAM(
-          node->get_logger(),
+          node_->get_logger(),
           "3D Mid point between the two markers in undistorted pixel coordinates = (" <<
             u[0] << ", " << v[0] << ")");
 
-        // paint a circle in the mid point of the normalized coordinates of both markers
-        cv::circle(inImage, cv::Point(u[0], v[0]), 3, cv::Scalar(0, 0, 255), cv::FILLED);
+        // paint a circle in the mid point of the normalized coordinates of both markers_
+        cv::circle(inImage_, cv::Point(u[0], v[0]), 3, cv::Scalar(0, 0, 255), cv::FILLED);
       }
 
       // draw a 3D cube in each marker if there is 3D info
-      if (camParam.isValid() && marker_size > 0) {
-        for (unsigned int i = 0; i < markers.size(); ++i) {
-          aruco::CvDrawingUtils::draw3dCube(inImage, markers[i], camParam);
+      if (camParam_.isValid() && marker_size_ > 0) {
+        for (unsigned int i = 0; i < markers_.size(); ++i) {
+          aruco::CvDrawingUtils::draw3dCube(inImage_, markers_[i], camParam_);
         }
       }
 
-      if (image_pub.getNumSubscribers() > 0) {
+      if (image_pub_.getNumSubscribers() > 0) {
         // show input with augmented information
         cv_bridge::CvImage out_msg;
         out_msg.header.stamp = curr_stamp;
         out_msg.encoding = sensor_msgs::image_encodings::RGB8;
-        out_msg.image = inImage;
-        image_pub.publish(out_msg.toImageMsg());
+        out_msg.image = inImage_;
+        image_pub_.publish(out_msg.toImageMsg());
       }
 
-      if (debug_pub.getNumSubscribers() > 0) {
+      if (debug_pub_.getNumSubscribers() > 0) {
         // show also the internal image resulting from the threshold operation
         cv_bridge::CvImage debug_msg;
         debug_msg.header.stamp = curr_stamp;
         debug_msg.encoding = sensor_msgs::image_encodings::MONO8;
-        debug_msg.image = mDetector.getThresholdedImage();
-        debug_pub.publish(debug_msg.toImageMsg());
+        debug_msg.image = mDetector_.getThresholdedImage();
+        debug_pub_.publish(debug_msg.toImageMsg());
       }
 
       RCLCPP_DEBUG(
-        node->get_logger(), "runtime: %f ms",
+        node_->get_logger(), "runtime: %f ms",
         1000 * (cv::getTickCount() - ticksBefore) / cv::getTickFrequency());
     } catch (cv_bridge::Exception & e) {
-      RCLCPP_ERROR(node->get_logger(), "cv_bridge exception: %s", e.what());
+      RCLCPP_ERROR(node_->get_logger(), "cv_bridge exception: %s", e.what());
       return;
     }
   }
@@ -230,89 +230,89 @@ void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
 // wait for one camerainfo and then don't update the info
 void cam_info_callback(const sensor_msgs::msg::CameraInfo & msg)
 {
-  if (!cam_info_received) {
-    camParam = aruco_ros::rosCameraInfo2ArucoCamParams(msg, useRectifiedImages);
-    cam_info_received = true;
+  if (!cam_info_received_) {
+    camParam_ = aruco_ros::rosCameraInfo2ArucoCamParams(msg, useRectifiedImages_);
+    cam_info_received_ = true;
   }
 }
 
 // void reconf_callback(aruco_ros::ArucoThresholdConfig &config, std::uint32_t level)
 // {
-//   mDetector.setDetectionMode(aruco::DetectionMode(config.detection_mode), config.min_image_size);
-//   normalizeImageIllumination = config.normalizeImage;
-//   dctComponentsToRemove = config.dctComponentsToRemove;
+//   mDetector_.setDetectionMode(aruco::DetectionMode(config.detection_mode), config.min_image_size);
+//   normalizeImageIllumination_ = config.normalizeImage;
+//   dctComponentsToRemove_ = config.dctComponentsToRemove_;
 // }
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  node = std::make_shared<rclcpp::Node>("aruco_double");
-  subNode = node->create_sub_node(node->get_name());
+  node_ = std::make_shared<rclcpp::Node>("aruco_double");
+  subNode_ = node_->create_sub_node(node_->get_name());
 
   // Declare node parameters
-  node->declare_parameter<bool>("image_is_rectified", true);
-  node->declare_parameter<double>("marker_size", 0.05);
-  node->declare_parameter<int>("marker_id1", 582);
-  node->declare_parameter<int>("marker_id2", 26);
-  node->declare_parameter<bool>("normalizeImage", true);
-  node->declare_parameter<int>("dct_components_to_remove", 2);
-  node->declare_parameter<std::string>("parent_name", "");
-  node->declare_parameter<std::string>("child_name1", "");
-  node->declare_parameter<std::string>("child_name2", "");
+  node_->declare_parameter<bool>("image_is_rectified", true);
+  node_->declare_parameter<double>("marker_size", 0.05);
+  node_->declare_parameter<int>("marker_id1", 582);
+  node_->declare_parameter<int>("marker_id2", 26);
+  node_->declare_parameter<bool>("normalizeImage", true);
+  node_->declare_parameter<int>("dct_components_to_remove", 2);
+  node_->declare_parameter<std::string>("parent_name", "");
+  node_->declare_parameter<std::string>("child_name1", "");
+  node_->declare_parameter<std::string>("child_name2", "");
 
-  image_transport::ImageTransport it(node);
+  image_transport::ImageTransport it(node_);
 
-  tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*node.get());
+  tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*node_.get());
 
   // dynamic_reconfigure::Server<aruco_ros::ArucoThresholdConfig> server;
   // dynamic_reconfigure::Server<aruco_ros::ArucoThresholdConfig>::CallbackType f_;
   // f_ = boost::bind(&reconf_callback, _1, _2);
   // server.setCallback(f_);
 
-  normalizeImageIllumination = false;
+  normalizeImageIllumination_ = false;
 
-  node->get_parameter_or<bool>("image_is_rectified", useRectifiedImages, true);
-  RCLCPP_INFO_STREAM(node->get_logger(), "Image is rectified: " << useRectifiedImages);
+  node_->get_parameter_or<bool>("image_is_rectified", useRectifiedImages_, true);
+  RCLCPP_INFO_STREAM(node_->get_logger(), "Image is rectified: " << useRectifiedImages_);
 
   image_transport::Subscriber image_sub = it.subscribe("/image", 1, &image_callback);
-  cam_info_sub = node->create_subscription<sensor_msgs::msg::CameraInfo>(
+  cam_info_sub_ = node_->create_subscription<sensor_msgs::msg::CameraInfo>(
     "/camera_info", 1,
     cam_info_callback);
 
-  cam_info_received = false;
-  image_pub = it.advertise(node->get_name() + std::string("/result"), 1);
-  debug_pub = it.advertise(node->get_name() + std::string("/debug"), 1);
-  pose_pub1 = subNode->create_publisher<geometry_msgs::msg::Pose>("pose", 100);
-  pose_pub2 = subNode->create_publisher<geometry_msgs::msg::Pose>("pose2", 100);
+  cam_info_received_ = false;
+  image_pub_ = it.advertise(node_->get_name() + std::string("/result"), 1);
+  debug_pub_ = it.advertise(node_->get_name() + std::string("/debug"), 1);
+  pose_pub1_ = subNode_->create_publisher<geometry_msgs::msg::Pose>("pose", 100);
+  pose_pub2_ = subNode_->create_publisher<geometry_msgs::msg::Pose>("pose2", 100);
 
-  node->get_parameter_or<double>("marker_size", marker_size, 0.05);
-  node->get_parameter_or<int>("marker_id1", marker_id1, 582);
-  node->get_parameter_or<int>("marker_id2", marker_id2, 26);
-  node->get_parameter_or<bool>("normalizeImage", normalizeImageIllumination, true);
-  node->get_parameter_or<int>("dct_components_to_remove", dctComponentsToRemove, 2);
-  if (dctComponentsToRemove == 0) {
-    normalizeImageIllumination = false;
+  node_->get_parameter_or<double>("marker_size_", marker_size_, 0.05);
+  node_->get_parameter_or<int>("marker_id1_", marker_id1_, 582);
+  node_->get_parameter_or<int>("marker_id2_", marker_id2_, 26);
+  node_->get_parameter_or<bool>("normalizeImage", normalizeImageIllumination_, true);
+  node_->get_parameter_or<int>("dct_components_to_remove", dctComponentsToRemove_, 2);
+  if (dctComponentsToRemove_ == 0) {
+    normalizeImageIllumination_ = false;
   }
 
-  node->get_parameter_or<std::string>("parent_name", parent_name, "");
-  node->get_parameter_or<std::string>("child_name1", child_name1, "");
-  node->get_parameter_or<std::string>("child_name2", child_name2, "");
+  node_->get_parameter_or<std::string>("parent_name_", parent_name_, "");
+  node_->get_parameter_or<std::string>("child_name1_", child_name1_, "");
+  node_->get_parameter_or<std::string>("child_name2_", child_name2_, "");
 
-  if (parent_name == "" || child_name1 == "" || child_name2 == "") {
-    RCLCPP_ERROR(node->get_logger(), "parent_name and/or child_name was not set!");
+  if (parent_name_ == "" || child_name1_ == "" || child_name2_ == "") {
+    RCLCPP_ERROR(node_->get_logger(), "parent_name and/or child_name was not set!");
     rclcpp::shutdown();
     return -1;
   }
 
   RCLCPP_INFO(
-    node->get_logger(),
+    node_->get_logger(),
     "ArUco node started with marker size of %f meters and marker ids to track: %d, %d",
-    marker_size, marker_id1, marker_id2);
+    marker_size_, marker_id1_, marker_id2_);
   RCLCPP_INFO(
-    node->get_logger(),
+    node_->get_logger(),
     "ArUco node will publish pose to TF with (%s, %s) and (%s, %s) as (parent,child).",
-    parent_name.c_str(), child_name1.c_str(), parent_name.c_str(), child_name2.c_str());
+    parent_name_.c_str(), child_name1_.c_str(), parent_name_.c_str(), child_name2_.c_str());
 
-  rclcpp::spin(node);
+  rclcpp::spin(node_);
   rclcpp::shutdown();
 }

--- a/aruco_ros/src/simple_single.cpp
+++ b/aruco_ros/src/simple_single.cpp
@@ -59,32 +59,32 @@
 class ArucoSimple : public rclcpp::Node
 {
 private:
-  rclcpp::Node::SharedPtr subNode;
-  cv::Mat inImage;
-  aruco::CameraParameters camParam;
-  tf2::Stamped<tf2::Transform> rightToLeft;
-  bool useRectifiedImages;
-  aruco::MarkerDetector mDetector;
-  std::vector<aruco::Marker> markers;
-  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr cam_info_sub;
-  bool cam_info_received;
-  image_transport::Publisher image_pub;
-  image_transport::Publisher debug_pub;
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub;
-  rclcpp::Publisher<geometry_msgs::msg::TransformStamped>::SharedPtr transform_pub;
-  rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr position_pub;
+  rclcpp::Node::SharedPtr subNode_;
+  cv::Mat inImage_;
+  aruco::CameraParameters camParam_;
+  tf2::Stamped<tf2::Transform> rightToLeft_;
+  bool useRectifiedImages_;
+  aruco::MarkerDetector mDetector_;
+  std::vector<aruco::Marker> markers_;
+  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr cam_info_sub_;
+  bool cam_info_received_;
+  image_transport::Publisher image_pub_;
+  image_transport::Publisher debug_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TransformStamped>::SharedPtr transform_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr position_pub_;
   // rviz visualization marker
-  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr marker_pub;
-  rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr pixel_pub;
-  std::string marker_frame;
-  std::string camera_frame;
-  std::string reference_frame;
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr marker_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr pixel_pub_;
+  std::string marker_frame_;
+  std::string camera_frame_;
+  std::string reference_frame_;
 
-  double marker_size;
-  int marker_id;
+  double marker_size_;
+  int marker_id_;
 
   std::unique_ptr<image_transport::ImageTransport> it_;
-  image_transport::Subscriber image_sub;
+  image_transport::Subscriber image_sub_;
 
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
@@ -92,7 +92,7 @@ private:
 
 public:
   ArucoSimple()
-  : Node("aruco_single"), cam_info_received(false)
+  : Node("aruco_single"), cam_info_received_(false)
   {
   }
 
@@ -100,7 +100,7 @@ public:
   {
     tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
-    subNode = this->create_sub_node(this->get_name());
+    subNode_ = this->create_sub_node(this->get_name());
 
     it_ = std::make_unique<image_transport::ImageTransport>(shared_from_this());
     tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(this);
@@ -111,7 +111,7 @@ public:
         "corner_refinement ROS parameter is deprecated");
     }
 
-    aruco::MarkerDetector::Params params = mDetector.getParameters();
+    aruco::MarkerDetector::Params params = mDetector_.getParameters();
     std::string thresh_method;
     switch (params.thresMethod) {
       case aruco::MarkerDetector::ThresMethod::THRES_ADAPTIVE:
@@ -144,55 +144,55 @@ public:
     std::string detection_mode;
     this->get_parameter_or<std::string>("detection_mode", detection_mode, "DM_FAST");
     if (detection_mode == "DM_FAST") {
-      mDetector.setDetectionMode(aruco::DM_FAST, min_marker_size);
+      mDetector_.setDetectionMode(aruco::DM_FAST, min_marker_size);
     } else if (detection_mode == "DM_VIDEO_FAST") {
-      mDetector.setDetectionMode(aruco::DM_VIDEO_FAST, min_marker_size);
+      mDetector_.setDetectionMode(aruco::DM_VIDEO_FAST, min_marker_size);
     } else {
       // Aruco version 2 mode
-      mDetector.setDetectionMode(aruco::DM_NORMAL, min_marker_size);
+      mDetector_.setDetectionMode(aruco::DM_NORMAL, min_marker_size);
     }
 
     RCLCPP_INFO_STREAM(
       this->get_logger(), "Marker size min: " << min_marker_size << " of image area");
     RCLCPP_INFO_STREAM(this->get_logger(), "Detection mode: " << detection_mode);
 
-    image_sub = it_->subscribe("/image", 1, &ArucoSimple::image_callback, this);
-    cam_info_sub = this->create_subscription<sensor_msgs::msg::CameraInfo>(
+    image_sub_ = it_->subscribe("/image", 1, &ArucoSimple::image_callback, this);
+    cam_info_sub_ = this->create_subscription<sensor_msgs::msg::CameraInfo>(
       "/camera_info", 1, std::bind(
         &ArucoSimple::cam_info_callback, this,
         std::placeholders::_1));
 
-    image_pub = it_->advertise(this->get_name() + std::string("/result"), 1);
-    debug_pub = it_->advertise(this->get_name() + std::string("/debug"), 1);
-    pose_pub = subNode->create_publisher<geometry_msgs::msg::PoseStamped>("pose", 100);
-    transform_pub =
-      subNode->create_publisher<geometry_msgs::msg::TransformStamped>("transform", 100);
-    position_pub = subNode->create_publisher<geometry_msgs::msg::Vector3Stamped>("position", 100);
-    marker_pub = subNode->create_publisher<visualization_msgs::msg::Marker>("marker", 10);
-    pixel_pub = subNode->create_publisher<geometry_msgs::msg::PointStamped>("pixel", 10);
+    image_pub_ = it_->advertise(this->get_name() + std::string("/result"), 1);
+    debug_pub_ = it_->advertise(this->get_name() + std::string("/debug"), 1);
+    pose_pub_ = subNode_->create_publisher<geometry_msgs::msg::PoseStamped>("pose", 100);
+    transform_pub_ =
+      subNode_->create_publisher<geometry_msgs::msg::TransformStamped>("transform", 100);
+    position_pub_ = subNode_->create_publisher<geometry_msgs::msg::Vector3Stamped>("position", 100);
+    marker_pub_ = subNode_->create_publisher<visualization_msgs::msg::Marker>("marker", 10);
+    pixel_pub_ = subNode_->create_publisher<geometry_msgs::msg::PointStamped>("pixel", 10);
 
-    this->get_parameter_or<double>("marker_size", marker_size, 0.05);
-    this->get_parameter_or<int>("marker_id", marker_id, 300);
-    this->get_parameter_or<std::string>("reference_frame", reference_frame, "");
-    this->get_parameter_or<std::string>("camera_frame", camera_frame, "");
-    this->get_parameter_or<std::string>("marker_frame", marker_frame, "");
-    this->get_parameter_or<bool>("image_is_rectified", useRectifiedImages, true);
+    this->get_parameter_or<double>("marker_size", marker_size_, 0.05);
+    this->get_parameter_or<int>("marker_id", marker_id_, 300);
+    this->get_parameter_or<std::string>("reference_frame", reference_frame_, "");
+    this->get_parameter_or<std::string>("camera_frame", camera_frame_, "");
+    this->get_parameter_or<std::string>("marker_frame", marker_frame_, "");
+    this->get_parameter_or<bool>("image_is_rectified", useRectifiedImages_, true);
 
     rcpputils::assert_true(
-      camera_frame != "" && marker_frame != "",
+      camera_frame_ != "" && marker_frame_ != "",
       "Found the camera frame or the marker_frame to be empty!. camera_frame : " +
-      camera_frame + " and marker_frame : " + marker_frame);
+      camera_frame_ + " and marker_frame : " + marker_frame_);
 
-    if (reference_frame.empty()) {
-      reference_frame = camera_frame;
+    if (reference_frame_.empty()) {
+      reference_frame_ = camera_frame_;
     }
 
     RCLCPP_INFO(
       this->get_logger(), "ArUco node started with marker size of %f m and marker id to track: %d",
-      marker_size, marker_id);
+      marker_size_, marker_id_);
     RCLCPP_INFO(
       this->get_logger(), "ArUco node will publish pose to TF with %s as parent and %s as child.",
-      reference_frame.c_str(), marker_frame.c_str());
+      reference_frame_.c_str(), marker_frame_.c_str());
 
     // dyn_rec_server.setCallback(boost::bind(&ArucoSimple::reconf_callback, this, _1, _2));
     RCLCPP_INFO(this->get_logger(), "Setup of aruco_simple node is successful!");
@@ -228,73 +228,73 @@ public:
 
   void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
   {
-    if ((image_pub.getNumSubscribers() == 0) &&
-      (debug_pub.getNumSubscribers() == 0) &&
-      (pose_pub->get_subscription_count() == 0) &&
-      (transform_pub->get_subscription_count() == 0) &&
-      (position_pub->get_subscription_count() == 0) &&
-      (marker_pub->get_subscription_count() == 0) &&
-      (pixel_pub->get_subscription_count() == 0))
+    if ((image_pub_.getNumSubscribers() == 0) &&
+      (debug_pub_.getNumSubscribers() == 0) &&
+      (pose_pub_->get_subscription_count() == 0) &&
+      (transform_pub_->get_subscription_count() == 0) &&
+      (position_pub_->get_subscription_count() == 0) &&
+      (marker_pub_->get_subscription_count() == 0) &&
+      (pixel_pub_->get_subscription_count() == 0))
     {
       RCLCPP_DEBUG(this->get_logger(), "No subscribers, not looking for ArUco markers");
       return;
     }
 
-    if (cam_info_received) {
+    if (cam_info_received_) {
       builtin_interfaces::msg::Time curr_stamp = msg->header.stamp;
       cv_bridge::CvImagePtr cv_ptr;
       try {
         cv_ptr = cv_bridge::toCvCopy(*msg, sensor_msgs::image_encodings::RGB8);
-        inImage = cv_ptr->image;
+        inImage_ = cv_ptr->image;
 
         // detection results will go into "markers"
-        markers.clear();
+        markers_.clear();
         // ok, let's detect
-        mDetector.detect(inImage, markers, camParam, marker_size, false);
+        mDetector_.detect(inImage_, markers_, camParam_, marker_size_, false);
         // for each marker, draw info and its boundaries in the image
-        for (std::size_t i = 0; i < markers.size(); ++i) {
+        for (std::size_t i = 0; i < markers_.size(); ++i) {
           // only publishing the selected marker
-          if (markers[i].id == marker_id) {
-            tf2::Transform transform = aruco_ros::arucoMarker2Tf2(markers[i]);
+          if (markers_[i].id == marker_id_) {
+            tf2::Transform transform = aruco_ros::arucoMarker2Tf2(markers_[i]);
             tf2::Stamped<tf2::Transform> cameraToReference;
             cameraToReference.setIdentity();
 
-            if (reference_frame != camera_frame) {
+            if (reference_frame_ != camera_frame_) {
               geometry_msgs::msg::TransformStamped transform_stamped;
-              getTransform(reference_frame, camera_frame, transform_stamped);
+              getTransform(reference_frame_, camera_frame_, transform_stamped);
               tf2::fromMsg(transform_stamped, cameraToReference);
             }
 
             transform = static_cast<tf2::Transform>(cameraToReference) *
-              static_cast<tf2::Transform>(rightToLeft) *
+              static_cast<tf2::Transform>(rightToLeft_) *
               transform;
 
             geometry_msgs::msg::TransformStamped stampedTransform;
-            stampedTransform.header.frame_id = reference_frame;
+            stampedTransform.header.frame_id = reference_frame_;
             stampedTransform.header.stamp = curr_stamp;
-            stampedTransform.child_frame_id = marker_frame;
+            stampedTransform.child_frame_id = marker_frame_;
             tf2::toMsg(transform, stampedTransform.transform);
             tf_broadcaster_->sendTransform(stampedTransform);
             geometry_msgs::msg::PoseStamped poseMsg;
             poseMsg.header = stampedTransform.header;
             tf2::toMsg(transform, poseMsg.pose);
-            poseMsg.header.frame_id = reference_frame;
+            poseMsg.header.frame_id = reference_frame_;
             poseMsg.header.stamp = curr_stamp;
-            pose_pub->publish(poseMsg);
+            pose_pub_->publish(poseMsg);
 
-            transform_pub->publish(stampedTransform);
+            transform_pub_->publish(stampedTransform);
 
             geometry_msgs::msg::Vector3Stamped positionMsg;
             positionMsg.header = stampedTransform.header;
             positionMsg.vector = stampedTransform.transform.translation;
-            position_pub->publish(positionMsg);
+            position_pub_->publish(positionMsg);
 
             geometry_msgs::msg::PointStamped pixelMsg;
             pixelMsg.header = stampedTransform.header;
-            pixelMsg.point.x = markers[i].getCenter().x;
-            pixelMsg.point.y = markers[i].getCenter().y;
+            pixelMsg.point.x = markers_[i].getCenter().x;
+            pixelMsg.point.y = markers_[i].getCenter().y;
             pixelMsg.point.z = 0;
-            pixel_pub->publish(pixelMsg);
+            pixel_pub_->publish(pixelMsg);
 
             // publish rviz marker representing the ArUco marker patch
             visualization_msgs::msg::Marker visMarker;
@@ -303,8 +303,8 @@ public:
             visMarker.type = visualization_msgs::msg::Marker::CUBE;
             visMarker.action = visualization_msgs::msg::Marker::ADD;
             visMarker.pose = poseMsg.pose;
-            visMarker.scale.x = marker_size;
-            visMarker.scale.y = marker_size;
+            visMarker.scale.x = marker_size_;
+            visMarker.scale.y = marker_size_;
             visMarker.scale.z = 0.001;
             visMarker.color.r = 1.0;
             visMarker.color.g = 0;
@@ -312,35 +312,35 @@ public:
             visMarker.color.a = 1.0;
             visMarker.lifetime = builtin_interfaces::msg::Duration();
             visMarker.lifetime.sec = 3;
-            marker_pub->publish(visMarker);
+            marker_pub_->publish(visMarker);
           }
           // but drawing all the detected markers
-          markers[i].draw(inImage, cv::Scalar(0, 0, 255), 2);
+          markers_[i].draw(inImage_, cv::Scalar(0, 0, 255), 2);
         }
 
         // draw a 3d cube in each marker if there is 3d info
-        if (camParam.isValid() && marker_size > 0) {
-          for (std::size_t i = 0; i < markers.size(); ++i) {
-            aruco::CvDrawingUtils::draw3dAxis(inImage, markers[i], camParam);
+        if (camParam_.isValid() && marker_size_ > 0) {
+          for (std::size_t i = 0; i < markers_.size(); ++i) {
+            aruco::CvDrawingUtils::draw3dAxis(inImage_, markers_[i], camParam_);
           }
         }
 
-        if (image_pub.getNumSubscribers() > 0) {
+        if (image_pub_.getNumSubscribers() > 0) {
           // show input with augmented information
           cv_bridge::CvImage out_msg;
           out_msg.header.stamp = curr_stamp;
           out_msg.encoding = sensor_msgs::image_encodings::RGB8;
-          out_msg.image = inImage;
-          image_pub.publish(out_msg.toImageMsg());
+          out_msg.image = inImage_;
+          image_pub_.publish(out_msg.toImageMsg());
         }
 
-        if (debug_pub.getNumSubscribers() > 0) {
+        if (debug_pub_.getNumSubscribers() > 0) {
           // show also the internal image resulting from the threshold operation
           cv_bridge::CvImage debug_msg;
           debug_msg.header.stamp = curr_stamp;
           debug_msg.encoding = sensor_msgs::image_encodings::MONO8;
-          debug_msg.image = mDetector.getThresholdedImage();
-          debug_pub.publish(debug_msg.toImageMsg());
+          debug_msg.image = mDetector_.getThresholdedImage();
+          debug_pub_.publish(debug_msg.toImageMsg());
         }
       } catch (cv_bridge::Exception & e) {
         RCLCPP_ERROR(this->get_logger(), "cv_bridge exception: %s", e.what());
@@ -352,21 +352,21 @@ public:
   // wait for one camerainfo, then shut down that subscriber
   void cam_info_callback(const sensor_msgs::msg::CameraInfo & msg)
   {
-    if (!cam_info_received) {
-      camParam = aruco_ros::rosCameraInfo2ArucoCamParams(msg, useRectifiedImages);
+    if (!cam_info_received_) {
+      camParam_ = aruco_ros::rosCameraInfo2ArucoCamParams(msg, useRectifiedImages_);
 
       // handle cartesian offset between stereo pairs
       // see the sensor_msgs/CameraInfo documentation for details
-      rightToLeft.setIdentity();
-      rightToLeft.setOrigin(tf2::Vector3(-msg.p[3] / msg.p[0], -msg.p[7] / msg.p[5], 0.0));
+      rightToLeft_.setIdentity();
+      rightToLeft_.setOrigin(tf2::Vector3(-msg.p[3] / msg.p[0], -msg.p[7] / msg.p[5], 0.0));
 
-      cam_info_received = true;
+      cam_info_received_ = true;
     }
   }
 
 //  void reconf_callback(aruco_ros::ArucoThresholdConfig & config, uint32_t level)
 //  {
-//    mDetector.setDetectionMode(
+//    mDetector_.setDetectionMode(
 //      aruco::DetectionMode(config.detection_mode),
 //      config.min_image_size);
 //    if (config.normalizeImage) {


### PR DESCRIPTION
While going through the code, I felt the need to have a naming convention for the private variables, like keeping _ (underscore at last of the each name). But found a mix of both which makes a code less readable. Although it's not a functional change but having a correct naming convention can help in better understanding,

Fixes #144 